### PR TITLE
I have timing issue (OSX 10.10, low power mode).

### DIFF
--- a/python/examples/rgb.py
+++ b/python/examples/rgb.py
@@ -36,5 +36,6 @@ print("Setting Mote to {r},{g},{b}".format(r=r,g=g,b=b))
 for channel in range(4):
     for pixel in range(16):
         mote.set_pixel(channel + 1, pixel, r, g, b)
+    time.sleep(0.01)
 
 mote.show()


### PR DESCRIPTION
Consistently I have only around 44 LEDs that are set to the right value, and then nothing (with the last on pixel at the wrong value sometime).
So that is 2*16 LEDs and +/- 12 LEDs on the 3rd stick.
Then the 4th stick is not turned on.

My hypothesis is that information is lost on the serial link.
Maybe missing flow control or something... but when the buffers are full, the last pixels don't get their data.

When I add that small delay, it solve the problem.

I knew my hardware was OK as the rainbow example was working.